### PR TITLE
Email sender changed to use mms.properties

### DIFF
--- a/src/main/java/gov/nasa/jpl/view_repo/actions/ActionUtil.java
+++ b/src/main/java/gov/nasa/jpl/view_repo/actions/ActionUtil.java
@@ -67,14 +67,11 @@ public class ActionUtil {
     
     private static String getContextUrl() {
         
-        String hostname = getHostName();
+        String hostname = EmsConfig.get("app.url");
         if (hostname.endsWith("/" )) {
             hostname = hostname.substring( 0, hostname.lastIndexOf( "/" ) );
         } 
-        if (!hostname.contains( EmsConfig.get("app.domain.name") )) {
-            hostname += "." + EmsConfig.get("app.domain.name");
-        }
-        return "https://" + hostname + "/alfresco"; 
+        return hostname + "/alfresco"; 
     }
     
     /**
@@ -138,7 +135,7 @@ public class ActionUtil {
         EmsScriptNode user = new EmsScriptNode(services.getPersonService().getPerson(username), services, new StringBuffer());
         String recipient = (String) user.getProperty("cm:email");
 
-        String sender = NodeUtil.getHostname() + "@" + EmsConfig.get("app.domain.name");
+        String sender = EmsConfig.get("app.email.from");
         sendEmailTo(sender, recipient, msg, subject, services);
     }
 

--- a/src/main/java/gov/nasa/jpl/view_repo/util/CommitUtil.java
+++ b/src/main/java/gov/nasa/jpl/view_repo/util/CommitUtil.java
@@ -939,9 +939,8 @@ public class CommitUtil {
 		    
 		    String msg = "Need to run model2postgres to fix. Offending JSON is " + delta.toString();
 		    ServiceRegistry services = NodeUtil.getServices();
-		    String hostname = services.getSysAdminParams().getAlfrescoHost();
-            String sender = hostname + "@jpl.nasa.gov";
-		    String recipient = "mbee-dev-admin@jpl.nasa.gov";
+            String sender = getConfig( "app.email.admin" );
+		    String recipient = getConfig( "app.email.admin" );
 		    ActionUtil.sendEmailTo( sender, recipient, msg, subject,
 		                            services );
 

--- a/src/main/java/gov/nasa/jpl/view_repo/util/NodeUtil.java
+++ b/src/main/java/gov/nasa/jpl/view_repo/util/NodeUtil.java
@@ -4430,10 +4430,8 @@ public class NodeUtil {
                                               ServiceRegistry services ) {
         // FIXME: need to base the single send on the same subject
         if ( !heisenbugSeen ) {
-            String hostname = services.getSysAdminParams().getAlfrescoHost();
-
-            String sender = hostname + "@" + EmsConfig.get( "app.domain.name" );
-            String recipient;
+            String sender = EmsConfig.get( "app.email.from" );
+            String recipient = EmsConfig.get( "app.email.admin" );
 
             recipient = EmsConfig.get( "app.email.admin" );
             ActionUtil.sendEmailTo( sender, recipient, msg, subject, services );

--- a/src/main/java/gov/nasa/jpl/view_repo/webscripts/AbstractJavaWebScript.java
+++ b/src/main/java/gov/nasa/jpl/view_repo/webscripts/AbstractJavaWebScript.java
@@ -1419,9 +1419,8 @@ public abstract class AbstractJavaWebScript extends DeclarativeJavaWebScript {
 
         // Email the progress (this takes a long time, so only do it for critical events):
         if (sendEmail) {
-            String hostname = NodeUtil.getHostname();
-            if (!Utils.isNullOrEmpty( hostname )) {
-                String sender = hostname + "@" + getConfig( "app.domain.name" );
+            String sender = getConfig("app.email.from");
+            if (!Utils.isNullOrEmpty( sender )) {
                 String username = NodeUtil.getUserName();
                 if (!Utils.isNullOrEmpty( username )) {
                     EmsScriptNode user = new EmsScriptNode(services.getPersonService().getPerson(username),


### PR DESCRIPTION
Our email system doesn't allow arbitrary senders. Changed sender generation code to use values from mms.properties.

This pull request may need to be changed to include the hostname in the subject or in the body of the email, if that information is still required.
